### PR TITLE
R2 display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ install-common:
 	install -D appvm-scripts/etc/tmpfiles.d/qubes-pulseaudio.conf $(DESTDIR)/usr/lib/tmpfiles.d/qubes-pulseaudio.conf
 	install -D appvm-scripts/etc/tmpfiles.d/qubes-session.conf $(DESTDIR)/usr/lib/tmpfiles.d/qubes-session.conf
 	install -D appvm-scripts/etc/xdgautostart/qubes-pulseaudio.desktop $(DESTDIR)/etc/xdg/autostart/qubes-pulseaudio.desktop
+	install -D appvm-scripts/etc/xdg/Trolltech.conf $(DESTDIR)/etc/xdg/Trolltech.conf
 	install -D appvm-scripts/qubes-gui-vm.gschema.override $(DESTDIR)$(DATADIR)/glib-2.0/schemas/20_qubes-gui-vm.gschema.override
 	install -m 0644 -D appvm-scripts/etc/qubes-rpc/qubes.SetMonitorLayout $(DESTDIR)/etc/qubes-rpc/qubes.SetMonitorLayout
 	install -d $(DESTDIR)/var/log/qubes

--- a/appvm-scripts/etc/X11/Xsession.d/20qt-x11-no-mitshm
+++ b/appvm-scripts/etc/X11/Xsession.d/20qt-x11-no-mitshm
@@ -1,0 +1,2 @@
+# Stops Qt form using the MIT-SHM X11 Shared Memory Extension
+export QT_X11_NO_MITSHM=1

--- a/appvm-scripts/etc/xdg/Trolltech.conf
+++ b/appvm-scripts/etc/xdg/Trolltech.conf
@@ -1,0 +1,15 @@
+[Qt]
+embedFonts=true
+style=gtk+
+doubleClickInterval=400
+cursorFlashTime=1000
+wheelScrollLines=3
+resolveSymlinks=false
+globalStrut\width=0
+globalStrut\height=0
+useRtlExtensions=false
+XIMInputStyle=On The Spot
+DefaultInputMethod=xim
+audiosink=Auto
+videomode=Auto
+GUIEffects=none

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Homepage: http://www.qubes-os.org/
 Package: qubes-gui-agent
 Architecture: any
 Depends: gnome-keyring, pulseaudio, xserver-xorg-core, xinit, x11-xserver-utils, xenstore-utils, qubes-core-agent, libpulse0, libxdamage1, libxcomposite1, libxt6, libx11-6, ${shlibs:Depends}, ${misc:Depends}
+Recommends: qt4-qtconfig
 Provides: x-display-manager
 Description: Makes X11 windows available to qubes dom0
  The Qubes GUI agent allows the forwarding of running app windows to the

--- a/rpm_spec/gui-vm.spec
+++ b/rpm_spec/gui-vm.spec
@@ -140,6 +140,7 @@ rm -f %{name}-%{version}
 /etc/profile.d/qubes-session.sh
 /etc/pulse/qubes-default.pa
 /etc/xdg/autostart/qubes-pulseaudio.desktop
+/etc/xdg/Trolltech.conf
 /etc/X11/xinit/xinitrc.d/qubes-keymap.sh
 /etc/qubes-rpc/qubes.SetMonitorLayout
 %config /etc/sysconfig/desktop


### PR DESCRIPTION
I have created commits for both R2 and R3.  As discussed, I added MIT-SHM export to Xresources.d

I also added a default QT configuration file (Trolltech.conf) to /etc/xdg.  It will be used as a default only (as this is the default location to place such a file for QT) if no file already exists in home directory and it's primarily purpose is to avoid ugly styling when an application is run as root via `sudo` as many are with Whonix.  Users are still able to define their own configuration without being effected.