### PR TITLE
Qt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ install-rh: appvm install-common
 	install -D appvm-scripts/etc/sysconfig/modules/qubes-u2mfn.modules $(DESTDIR)/etc/sysconfig/modules/qubes-u2mfn.modules
 	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/qubes-keymap.sh $(DESTDIR)/etc/X11/xinit/xinitrc.d/qubes-keymap.sh
 	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh $(DESTDIR)/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
+	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh $(DESTDIR)/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh
 	install -m 0644 -D appvm-scripts/etc/X11/Xwrapper.config $(DESTDIR)/etc/X11/Xwrapper.config
 
 install-debian: appvm install-common

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ install-rh: appvm install-common
 	install -D appvm-scripts/etc/sysconfig/desktop $(DESTDIR)/etc/sysconfig/desktop
 	install -D appvm-scripts/etc/sysconfig/modules/qubes-u2mfn.modules $(DESTDIR)/etc/sysconfig/modules/qubes-u2mfn.modules
 	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/qubes-keymap.sh $(DESTDIR)/etc/X11/xinit/xinitrc.d/qubes-keymap.sh
+	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh $(DESTDIR)/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
 	install -m 0644 -D appvm-scripts/etc/X11/Xwrapper.config $(DESTDIR)/etc/X11/Xwrapper.config
 
 install-debian: appvm install-common

--- a/appvm-scripts/etc/X11/Xsession.d/20qt-gnome-desktop-session-id.sh
+++ b/appvm-scripts/etc/X11/Xsession.d/20qt-gnome-desktop-session-id.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Prevents QT from displaying ugly QT theme
+if [ -z "$GNOME_DESKTOP_SESSION_ID" ]; then
+    export GNOME_DESKTOP_SESSION_ID="${XDG_SESSION_ID}"
+fi

--- a/appvm-scripts/etc/X11/Xsession.d/20qt-x11-no-mitshm
+++ b/appvm-scripts/etc/X11/Xsession.d/20qt-x11-no-mitshm
@@ -1,2 +1,0 @@
-# Stops Qt form using the MIT-SHM X11 Shared Memory Extension
-export QT_X11_NO_MITSHM=1

--- a/appvm-scripts/etc/X11/Xsession.d/20qt-x11-no-mitshm.sh
+++ b/appvm-scripts/etc/X11/Xsession.d/20qt-x11-no-mitshm.sh
@@ -1,0 +1,2 @@
+# Stops QT from using the MIT-SHM X11 Shared Memory Extension
+export QT_X11_NO_MITSHM=1

--- a/appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh
+++ b/appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh
@@ -1,0 +1,1 @@
+../../Xsession.d/20qt-gnome-desktop-session-id.sh

--- a/appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
+++ b/appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
@@ -1,0 +1,1 @@
+../../Xsession.d/20qt-x11-no-mitshm.sh

--- a/rpm_spec/gui-vm.spec
+++ b/rpm_spec/gui-vm.spec
@@ -147,6 +147,7 @@ rm -f %{name}-%{version}
 %config /etc/xdg/Trolltech.conf
 /etc/X11/xinit/xinitrc.d/qubes-keymap.sh
 /etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
+/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh
 %config /etc/X11/Xwrapper.config
 /etc/qubes-rpc/qubes.SetMonitorLayout
 %config /etc/sysconfig/desktop

--- a/rpm_spec/gui-vm.spec
+++ b/rpm_spec/gui-vm.spec
@@ -146,6 +146,7 @@ rm -f %{name}-%{version}
 /etc/xdg/autostart/qubes-pulseaudio.desktop
 %config /etc/xdg/Trolltech.conf
 /etc/X11/xinit/xinitrc.d/qubes-keymap.sh
+/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
 %config /etc/X11/Xwrapper.config
 /etc/qubes-rpc/qubes.SetMonitorLayout
 %config /etc/sysconfig/desktop


### PR DESCRIPTION
env QT_X11_NO_MITSHM: Stops QT from using the MIT-SHM X11 Shared Memory
env GNOME_DESKTOP_SESSION_ID: Prevents QT from displaying ugly QT theme