### PR TITLE
fix, qubes-mount-home.service -> qubes-mount-dirs.service

### DIFF
--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Qubes GUI Agent
-After=qubes-meminfo-writer.service qubes-mount-home.service
+After=qubes-meminfo-writer.service qubes-mount-dirs.service
 
 [Service]
 # pretend tha user is at local console


### PR DESCRIPTION
Has been forgotten by me in https://github.com/marmarek/qubes-core-agent-linux/pull/35.

When we rename systemd services, this can interact badly. (Related example:
[qubes-whonix-postinit.service](https://github.com/Whonix/qubes-whonix/blob/88e193a8a1d657c6f8c18e0fab6d9baedc3e7203/lib/systemd/system/qubes-whonix-postinit.service) no longer succeeds, because still using the old systemd unit name, which results in follow up issues.)

We need to grep all our packages for the old name and update to the new one so we also update all of systemd's `After=`, `Before=` and similar.

Hopefully this hasn't broken other things in Qubes.