### PR TITLE
clean up /etc/X11/Xsession.d/98qubes-session

### DIFF
--- a/debian/qubes-gui-agent.maintscript
+++ b/debian/qubes-gui-agent.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/X11/Xsession.d/98qubes-session


### PR DESCRIPTION
> ... missing DBUS_SESSION_BUS_ADDRESS

@marmarek:
> I guess it's about https://github.com/QubesOS/qubes-gui-agent-linux/commit/1ddc91
While the file (/etc/X11/Xsession.d/98qubes-session) isn't included in new package, it isn't cleaned up on upgrade.

Was discussed here:
https://forums.whonix.org/t/speed-up-time-synchronisation-with-asynchronous-time-fetching/1137/241?u=patrick

Analogous to:
https://github.com/marmarek/qubes-core-agent-linux/commit/f2e6dc93911123e3613f6b1d2e6a63a7661874da