### PR TITLE
archlinux: remove bugfixes related to pulseaudio

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -6,7 +6,7 @@
 # Maintainer: Olivier Medoc <o_medoc@yahoo.fr>
 pkgname=qubes-vm-gui
 pkgver=`cat version`
-pkgrel=5
+pkgrel=6
 epoch=
 pkgdesc="The Qubes GUI Agent for AppVMs"
 arch=("x86_64")

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -18,12 +18,6 @@ post_install() {
   ldconfig
   glib-compile-schemas /usr/share/glib-2.0/schemas &> /dev/null || :
 
-  # Archlinux specific: Disable pulseaudio autostart script
-  echo "" > /etc/X11/xinit/xinitrc.d/pulseaudio
-
-  # Archlinux specific: Then modify /etc/pacman.conf to ensure that this file won't be changed during upgrades. Add this line next to the commented NoUpgrade line:
-  sed '/NoUpgrade/aNoUpgrade = /etc/X11/xinit/xinitrc.d/pulseaudio' -i /etc/pacman.conf
-
   echo "Fixing bug in xinitrc"
   # Archlinux specific: Fix potential bug in xinitrc making dbus to not initilize correctly
   sed 's:for f in /etc/X11/xinit/xinitrc.d/?\*\.sh:for f in /etc/X11/xinit/xinitrc.d/?\*:' -i /etc/X11/xinit/xinitrc


### PR DESCRIPTION
Pulseaudio user daemon now uses systemd --user