### PR TITLE
archlinux: remove unnecessary glib-compile-scheme

### DIFF
--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -1,4 +1,3 @@
-
 # Imported from core-agent-linux
 configure_pulseaudio() {
  
@@ -16,7 +15,6 @@ post_install() {
   echo autospawn=no >> /etc/pulse/client.conf
 
   ldconfig
-  glib-compile-schemas /usr/share/glib-2.0/schemas &> /dev/null || :
 
   echo "Fixing bug in xinitrc"
   # Archlinux specific: Fix potential bug in xinitrc making dbus to not initilize correctly
@@ -27,22 +25,15 @@ post_install() {
 }
 
 post_upgrade() {
-
   post_install
-
 }
 
 ## arg 1:  the old package version
 pre_remove() {
-
   systemctl disable qubes-gui-agent.service
-  glib-compile-schemas /usr/share/glib-2.0/schemas &> /dev/null || :
 }
 
 post_remove() {
-
   ldconfig
-  glib-compile-schemas /usr/share/glib-2.0/schemas &> /dev/null || :
-
 }
 


### PR DESCRIPTION
This is now automatically handled through pacman hooks