### PR TITLE
Do not unconditionally load gnome-keyring environment

### DIFF
--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -39,11 +39,6 @@ VMTYPE=`/usr/bin/qubesdb-read /qubes-vm-type`
 UPDTYPE=`/usr/bin/qubesdb-read /qubes-vm-updateable`
 [[ $UPDTYPE == 'True' ]] && UPDTYPE="UpdateableVM" || UPDTYPE="NonUpdateableVM"
 
-# Gnome keyring is special case, as its env needed by nm-applet
-if [ -x /usr/bin/gnome-keyring-daemon ]; then
-    eval `/usr/bin/gnome-keyring-daemon --start`
-fi
-
 # process /etc/xdg/autostart and friends (according to Desktop Application
 # Autostart Specification)
 /usr/bin/qubes-session-autostart QUBES X-QUBES "X-$VMTYPE" "X-$UPDTYPE"


### PR DESCRIPTION
It makes impossible to use standard ssh-agent and the one from
gnome-keyring isn't perfect.

The reason why it was needed isn't true for a long time - NetworkManager
store wifi passwords and other credentials in its configuration files,
not gnome-keyring.

Anyway, if anyone want to restore old behaviour, it is still possible
using `/etc/X11/xinit/xinitrc.d/`. Or `~/.profile`, which is also
sourced there.

Fixes QubesOS/qubes-issues#2351